### PR TITLE
Fix Visual Studio Builds

### DIFF
--- a/vs10/masscan.vcxproj
+++ b/vs10/masscan.vcxproj
@@ -90,6 +90,7 @@
     <ClCompile Include="..\src\proto-vnc.c" />
     <ClCompile Include="..\src\proto-x509.c" />
     <ClCompile Include="..\src\proto-zeroaccess.c" />
+    <ClCompile Include="..\src\proto-minecraft.c" />
     <ClCompile Include="..\src\rand-blackrock.c" />
     <ClCompile Include="..\src\rand-lcg.c" />
     <ClCompile Include="..\src\rand-primegen.c" />
@@ -191,6 +192,7 @@
     <ClInclude Include="..\src\proto-vnc.h" />
     <ClInclude Include="..\src\proto-x509.h" />
     <ClInclude Include="..\src\proto-zeroaccess.h" />
+    <ClInclude Include="..\src\proto-minecraft.h" />
     <ClInclude Include="..\src\rand-blackrock.h" />
     <ClInclude Include="..\src\rand-lcg.h" />
     <ClInclude Include="..\src\rand-primegen.h" />


### PR DESCRIPTION
The `vs10/masscan.vcxproject` file was missing the newly added `proto-minecraft.c` and `proto-minecraft.h` files, thus breaking Visual Studio Builds.